### PR TITLE
Add executeShellRaw method to support to get output immediately

### DIFF
--- a/src/se/vidstige/jadb/AdbFilterInputStream.java
+++ b/src/se/vidstige/jadb/AdbFilterInputStream.java
@@ -31,6 +31,11 @@ public class AdbFilterInputStream extends FilterInputStream {
             if (b == -1) return n == 0 ? -1 : n;
             buffer[offset + n] = (byte) b;
             n++;
+
+            // Return as soon as no more data is available (and at least one byte was read)
+            if (in.available() <= 0) {
+                return n;
+            }
         }
         return n;
     }

--- a/src/se/vidstige/jadb/DeviceWatcher.java
+++ b/src/se/vidstige/jadb/DeviceWatcher.java
@@ -1,6 +1,5 @@
 package se.vidstige.jadb;
 
-import java.util.List;
 import java.io.IOException;
 
 public class DeviceWatcher implements Runnable {

--- a/src/se/vidstige/jadb/JadbConnection.java
+++ b/src/se/vidstige/jadb/JadbConnection.java
@@ -2,7 +2,6 @@ package se.vidstige.jadb;
 
 import java.io.IOException;
 import java.net.Socket;
-import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/se/vidstige/jadb/JadbDevice.java
+++ b/src/se/vidstige/jadb/JadbDevice.java
@@ -71,20 +71,15 @@ public class JadbDevice {
         return state;
     }
 
-    /** Execute a shell command with raw output.
+    /** Execute a shell command.
      *
-     * This function differs from executeShell in that no buffering and newline filtering is performed.
-     *
-     * Especially the buffering may be an issue if the output of an ongoing command should be displayed,
-     * e.g. the output of running logcat.
-     *
-     * @param command main command.
-     * @param args arguments to the commands
+     * @param command main command to run. E.g. "ls"
+     * @param args arguments to the command.
      * @return combined stdout/stderr stream.
      * @throws IOException
      * @throws JadbException
      */
-    public InputStream executeShellRaw(String command, String... args) throws IOException, JadbException {
+    public InputStream executeShell(String command, String... args) throws IOException, JadbException {
         Transport transport = getTransport();
         StringBuilder shellLine = new StringBuilder(command);
         for (String arg : args) {
@@ -92,20 +87,7 @@ public class JadbDevice {
             shellLine.append(Bash.quote(arg));
         }
         send(transport, "shell:" + shellLine.toString());
-        return transport.getInputStream();
-    }
-
-    /** Execute a shell command.
-     *
-     * @param command main command.
-     * @param args arguments to the commands
-     * @return combined stdout/stderr stream.
-     * @throws IOException
-     * @throws JadbException
-     */
-    public InputStream executeShell(String command, String... args) throws IOException, JadbException {
-        InputStream inputStream = executeShellRaw(command, args);
-    	return new AdbFilterInputStream(new BufferedInputStream(inputStream));
+        return new AdbFilterInputStream(new BufferedInputStream(transport.getInputStream()));
     }
 
     /**

--- a/src/se/vidstige/jadb/managers/PackageManager.java
+++ b/src/se/vidstige/jadb/managers/PackageManager.java
@@ -90,6 +90,7 @@ public class PackageManager {
 
     public void launch(Package name) throws IOException, JadbException {
         InputStream s = device.executeShell("monkey", "-p", name.toString(), "-c", "android.intent.category.LAUNCHER", "1");
+        s.close();
     }
 
     //<editor-fold desc="InstallOption">
@@ -132,7 +133,7 @@ public class PackageManager {
             new InstallOption("-d");
 
     /**
-     * This option is sSupported only from Android 6.X+
+     * This option is supported only from Android 6.X+
      */
     public static final InstallOption GRANT_ALL_PERMISSIONS = new InstallOption("-g");
 

--- a/test/se/vidstige/jadb/test/integration/RealDeviceTestCases.java
+++ b/test/se/vidstige/jadb/test/integration/RealDeviceTestCases.java
@@ -1,5 +1,6 @@
 package se.vidstige.jadb.test.integration;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -49,6 +50,7 @@ public class RealDeviceTestCases {
     @Test
     public void testGetDevices() throws Exception {
         List<JadbDevice> actual = jadb.getDevices();
+        Assert.assertNotNull(actual);
         //Assert.assertEquals("emulator-5554", actual.get(0).getSerial());
     }
 
@@ -92,7 +94,8 @@ public class RealDeviceTestCases {
         any.pull(new RemoteFile("/file/does/not/exist"), temporaryFolder.newFile("xyz"));
     }
 
-    @Test
+    @SuppressWarnings("deprecation")
+	@Test
     public void testShellExecuteTwice() throws Exception {
         JadbDevice any = jadb.getAnyDevice();
         any.executeShell(System.out, "ls /");

--- a/test/se/vidstige/jadb/test/unit/AdbOutputStreamFixture.java
+++ b/test/se/vidstige/jadb/test/unit/AdbOutputStreamFixture.java
@@ -13,8 +13,12 @@ public class AdbOutputStreamFixture {
     private byte[] passthrough(byte[] input) throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         OutputStream sut = new AdbFilterOutputStream(output);
-        sut.write(input);
-        sut.flush();
+        try {
+	        sut.write(input);
+	        sut.flush();
+        } finally {
+        	sut.close();
+        }
         return output.toByteArray();
     }
 

--- a/test/se/vidstige/jadb/test/unit/MockedTestCases.java
+++ b/test/se/vidstige/jadb/test/unit/MockedTestCases.java
@@ -8,7 +8,6 @@ import se.vidstige.jadb.JadbConnection;
 import se.vidstige.jadb.JadbDevice;
 import se.vidstige.jadb.JadbException;
 import se.vidstige.jadb.RemoteFile;
-import se.vidstige.jadb.managers.PropertyManager;
 import se.vidstige.jadb.test.fakes.FakeAdbServer;
 
 import java.io.ByteArrayInputStream;
@@ -18,7 +17,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.List;
-import java.util.Map;
 
 public class MockedTestCases {
 


### PR DESCRIPTION
The existing buffering does cause that output from a JadbDevice.executeShell("shell:logcat") call is only available to the caller once 8k content is available (or the process ends, which does not happen for logcat). This basically makes the current library unusable to get timely output from the target for long running commands, hence I exposed a new method executeShellRaw which bypasses the buffering and filtering of stdout/stderr.
Also some minor fixes for warnings in a separate commit.
