### PR TITLE
Fix some codes

### DIFF
--- a/src/se/vidstige/jadb/JadbConnection.java
+++ b/src/se/vidstige/jadb/JadbConnection.java
@@ -12,11 +12,11 @@ public class JadbConnection implements ITransportFactory {
 
     private static final int DEFAULTPORT = 5037;
 
-    public JadbConnection() throws IOException {
+    public JadbConnection() {
         this("localhost", DEFAULTPORT);
     }
 
-    public JadbConnection(String host, int port) throws IOException {
+    public JadbConnection(String host, int port) {
         this.host = host;
         this.port = port;
     }
@@ -25,16 +25,17 @@ public class JadbConnection implements ITransportFactory {
         return new Transport(new Socket(host, port));
     }
 
-    public void getHostVersion() throws IOException, JadbException {
+    public String getHostVersion() throws IOException, JadbException {
         Transport main = createTransport();
         main.send("host:version");
         main.verifyResponse();
+        String version = main.readString();
         main.close();
+        return version;
     }
 
     public List<JadbDevice> getDevices() throws IOException, JadbException {
         Transport devices = createTransport();
-
         devices.send("host:devices");
         devices.verifyResponse();
         String body = devices.readString();

--- a/test/se/vidstige/jadb/test/unit/MockedTestCases.java
+++ b/test/se/vidstige/jadb/test/unit/MockedTestCases.java
@@ -106,7 +106,7 @@ public class MockedTestCases {
     @Test
     public void testExecuteShellQuotesSpace() throws Exception {
         server.add("serial-123");
-        server.expectShell("serial-123", "ls 'space file'");
+        server.expectShell("serial-123", "ls 'space file'").returns("space file");
         JadbDevice device = connection.getDevices().get(0);
         device.executeShell("ls", "space file");
     }

--- a/test/se/vidstige/jadb/test/unit/MockedTestCases.java
+++ b/test/se/vidstige/jadb/test/unit/MockedTestCases.java
@@ -37,6 +37,11 @@ public class MockedTestCases {
     }
 
     @Test
+    public void testGetHostVersion() throws Exception {
+        Assert.assertEquals("001f", connection.getHostVersion());
+    }
+
+    @Test
     public void testListDevices() throws Exception {
         server.add("serial-123");
         List<JadbDevice> devices = connection.getDevices();


### PR DESCRIPTION
I fixed some codes below:

 - `throws` is specified in JadbConnection constructor, but no exceptions thrown. Removed `throws` clause. 
 - `getHostVersion` returns no result.  Changed to return Adb host version.
- NullPointerException is thrown in `testExecuteShellQuotesSpace`. Fixed this.