### PR TITLE
Property manager improvements

### DIFF
--- a/src/se/vidstige/jadb/managers/PropertyManager.java
+++ b/src/se/vidstige/jadb/managers/PropertyManager.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
  * A class which works with properties, uses getprop and setprop methods of android shell
  */
 public class PropertyManager {
+    private final Pattern pattern = Pattern.compile("^\\[([a-zA-Z0-9_.-]*)\\]:.\\[([^\\[\\]]*)\\]");
     private final JadbDevice device;
 
     public PropertyManager(JadbDevice device) {
@@ -27,8 +28,6 @@ public class PropertyManager {
     }
 
     private Map<String, String> parseProp(BufferedReader bufferedReader) throws IOException {
-        final Pattern pattern = Pattern.compile("^\\[([a-zA-Z0-9_.-]*)\\]:.\\[([^\\[\\]]*)\\]");
-
         HashMap<String, String> result = new HashMap<>();
 
         String line;

--- a/src/se/vidstige/jadb/managers/PropertyManager.java
+++ b/src/se/vidstige/jadb/managers/PropertyManager.java
@@ -27,7 +27,7 @@ public class PropertyManager {
     }
 
     private Map<String, String> parseProp(BufferedReader bufferedReader) throws IOException {
-        final Pattern pattern = Pattern.compile("^\\[([a-zA-Z0-9_.-]*)\\]:.\\[([a-zA-Z0-9_.-]*)\\]");
+        final Pattern pattern = Pattern.compile("^\\[([a-zA-Z0-9_.-]*)\\]:.\\[([^\\[\\]]*)\\]");
 
         HashMap<String, String> result = new HashMap<>();
 

--- a/src/se/vidstige/jadb/managers/PropertyManager.java
+++ b/src/se/vidstige/jadb/managers/PropertyManager.java
@@ -23,8 +23,15 @@ public class PropertyManager {
     }
 
     public Map<String, String> getprop() throws IOException, JadbException {
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(device.executeShell("getprop")));
-        return parseProp(bufferedReader);
+        BufferedReader bufferedReader = null;
+        try {
+            bufferedReader = new BufferedReader(new InputStreamReader(device.executeShell("getprop")));
+            return parseProp(bufferedReader);
+        } finally {
+            if (bufferedReader != null) {
+                bufferedReader.close();
+            }
+        }
     }
 
     private Map<String, String> parseProp(BufferedReader bufferedReader) throws IOException {

--- a/src/se/vidstige/jadb/managers/PropertyManager.java
+++ b/src/se/vidstige/jadb/managers/PropertyManager.java
@@ -23,14 +23,9 @@ public class PropertyManager {
     }
 
     public Map<String, String> getprop() throws IOException, JadbException {
-        BufferedReader bufferedReader = null;
-        try {
-            bufferedReader = new BufferedReader(new InputStreamReader(device.executeShell("getprop")));
+        try (BufferedReader bufferedReader =
+                     new BufferedReader(new InputStreamReader(device.executeShell("getprop")))) {
             return parseProp(bufferedReader);
-        } finally {
-            if (bufferedReader != null) {
-                bufferedReader.close();
-            }
         }
     }
 

--- a/test/se/vidstige/jadb/test/unit/PropertyManagerTest.java
+++ b/test/se/vidstige/jadb/test/unit/PropertyManagerTest.java
@@ -56,6 +56,38 @@ public class PropertyManagerTest {
     }
 
     @Test
+    public void testGetPropsValueHasSpecialCharacters() throws Exception {
+        /* Some example properties from Nexus 9:
+        [ro.product.model]: [Nexus 9]
+        [ro.product.cpu.abilist]: [arm64-v8a,armeabi-v7a,armeabi]
+        [ro.retaildemo.video_path]: [/data/preloads/demo/retail_demo.mp4]
+        [ro.url.legal]: [http://www.google.com/intl/%s/mobile/android/basic/phone-legal.html]
+        [ro.vendor.build.date]: [Tue Nov 1 18:21:23 UTC 2016]
+        */
+        //Arrange
+        Map<String, String> expected = new HashMap<>();
+        expected.put("ro.product.model", "Nexus 9");
+        expected.put("ro.product.cpu.abilist", "arm64-v8a,armeabi-v7a,armeabi");
+        expected.put("ro.retaildemo.video_path", "/data/preloads/demo/retail_demo.mp4");
+        expected.put("ro.url.legal", "http://www.google.com/intl/%s/mobile/android/basic/phone-legal.html");
+        expected.put("ro.vendor.build.date", "Tue Nov 1 18:21:23 UTC 2016");
+
+        String response = "[ro.product.model]: [Nexus 9]\n" +
+                "[ro.product.cpu.abilist]: [arm64-v8a,armeabi-v7a,armeabi]\n" +
+                "[ro.retaildemo.video_path]: [/data/preloads/demo/retail_demo.mp4]\n" +
+                "[ro.url.legal]: [http://www.google.com/intl/%s/mobile/android/basic/phone-legal.html]\n" +
+                "[ro.vendor.build.date]: [Tue Nov 1 18:21:23 UTC 2016]";
+
+        server.expectShell(DEVICE_SERIAL, "getprop").returns(response);
+
+        //Act
+        Map<String, String> actual = new PropertyManager(device).getprop();
+
+        //Assert
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testGetPropsMalformedIgnoredString() throws Exception {
         //Arrange
         Map<String, String> expected = new HashMap<>();


### PR DESCRIPTION
I noticed that PropertyManager doesn't get all properties from my Nexus 9. This happened because PropertyManager didn't allow for example spaces in values.

Changed PropertyManager to allow any character except square brackets in property value. Also,
as other improvements made pattern to be compiled only once and bufferedReader to be closed after parsing properties.