### PR TITLE
Don't use System.out as parameter in executeShell test

### DIFF
--- a/test/se/vidstige/jadb/test/integration/RealDeviceTestCases.java
+++ b/test/se/vidstige/jadb/test/integration/RealDeviceTestCases.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import se.vidstige.jadb.*;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -98,8 +99,10 @@ public class RealDeviceTestCases {
 	@Test
     public void testShellExecuteTwice() throws Exception {
         JadbDevice any = jadb.getAnyDevice();
-        any.executeShell(System.out, "ls /");
-        any.executeShell(System.out, "ls", "-la", "/");
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        any.executeShell(bout, "ls /");
+        any.executeShell(bout, "ls", "-la", "/");
+        System.out.write(bout.toByteArray());
     }
 
     @Test


### PR DESCRIPTION
Using System.out as parameter for executeShell causes test run to
stop in Windows host. Probably because deprecated executeShell
closes the given output stream.

Changed parameter stream in test to ByteArrayOutputStream to allow
tests to run in Windows system. Resulting byte array is then written
to System.out to preserve old behavior.