### PR TITLE
Package manager tests

### DIFF
--- a/src/se/vidstige/jadb/managers/Package.java
+++ b/src/se/vidstige/jadb/managers/Package.java
@@ -14,7 +14,16 @@ public class Package {
     public String toString() { return name; }
 
     @Override
-    public boolean equals(Object o) { return name.equals(o); }
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Package that = (Package) o;
+
+        if (!name.equals(that.name)) return false;
+
+        return true;
+        }
 
     @Override
     public int hashCode() { return name.hashCode(); }

--- a/src/se/vidstige/jadb/managers/Package.java
+++ b/src/se/vidstige/jadb/managers/Package.java
@@ -16,14 +16,10 @@ public class Package {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (!(o instanceof Package)) return false;
         Package that = (Package) o;
-
-        if (!name.equals(that.name)) return false;
-
-        return true;
-        }
+        return name.equals(that.name);
+    }
 
     @Override
     public int hashCode() { return name.hashCode(); }

--- a/test/se/vidstige/jadb/test/unit/PackageManagerTest.java
+++ b/test/se/vidstige/jadb/test/unit/PackageManagerTest.java
@@ -1,0 +1,94 @@
+package se.vidstige.jadb.test.unit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import se.vidstige.jadb.JadbConnection;
+import se.vidstige.jadb.JadbDevice;
+import se.vidstige.jadb.managers.Package;
+import se.vidstige.jadb.managers.PackageManager;
+import se.vidstige.jadb.test.fakes.FakeAdbServer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class PackageManagerTest {
+    private final String DEVICE_SERIAL = "serial-123";
+
+    private FakeAdbServer server;
+    private JadbConnection connection;
+    private JadbDevice device;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new FakeAdbServer(15037);
+        server.start();
+        server.add(DEVICE_SERIAL);
+        connection = new JadbConnection("localhost", 15037);
+
+        device = connection.getDevices().get(0);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+        server.verifyExpectations();
+    }
+
+    @Test
+    public void testGetPackagesWithSeveralPackages() throws Exception {
+        //Arrange
+        List<Package> expected = new ArrayList<>();
+        expected.add(new Package("/system/priv-app/Contacts.apk-com.android.contacts"));
+        expected.add(new Package("/system/priv-app/Teleservice.apk-com.android.phone"));
+
+        String response = "package:/system/priv-app/Contacts.apk-com.android.contacts\n" +
+                "package:/system/priv-app/Teleservice.apk-com.android.phone";
+
+        server.expectShell(DEVICE_SERIAL, "pm list packages").returns(response);
+
+        //Act
+        List<Package> actual = new PackageManager(device).getPackages();
+
+        //Assert
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetPackagesMalformedIgnoredString() throws Exception {
+        //Arrange
+        List<Package> expected = new ArrayList<>();
+        expected.add(new Package("/system/priv-app/Contacts.apk-com.android.contacts"));
+        expected.add(new Package("/system/priv-app/Teleservice.apk-com.android.phone"));
+
+        String response = "package:/system/priv-app/Contacts.apk-com.android.contacts\n" +
+                "[malformed_line]\n" +
+                "package:/system/priv-app/Teleservice.apk-com.android.phone";
+
+        server.expectShell(DEVICE_SERIAL, "pm list packages").returns(response);
+
+        //Act
+        List<Package> actual = new PackageManager(device).getPackages();
+
+        //Assert
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetPackagesWithNoPackages() throws Exception {
+        //Arrange
+        List<Package> expected = new ArrayList<>();
+        String response = "";
+
+        server.expectShell(DEVICE_SERIAL, "pm list packages").returns(response);
+
+        //Act
+        List<Package> actual = new PackageManager(device).getPackages();
+
+        //Assert
+        assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
Fixing #72 for the primary method in PackageManager.
Altering the equals method of Package for testing value equality.