### PR TITLE
Make transport closeable take 2

### DIFF
--- a/src/se/vidstige/jadb/JadbConnection.java
+++ b/src/se/vidstige/jadb/JadbConnection.java
@@ -28,41 +28,34 @@ public class JadbConnection implements ITransportFactory {
     }
 
     public String getHostVersion() throws IOException, JadbException {
-        Transport main = createTransport();
-        main.send("host:version");
-        main.verifyResponse();
-        String version = main.readString();
-        main.close();
-        return version;
+        try (Transport transport = createTransport()) {
+            transport.send("host:version");
+            transport.verifyResponse();
+            return transport.readString();
+        }
     }
 
     public InetSocketAddress connectToTcpDevice(InetSocketAddress inetSocketAddress)
             throws IOException, JadbException, ConnectionToRemoteDeviceException {
-        Transport transport = createTransport();
-        try {
+        try (Transport transport = createTransport()) {
             return new HostConnectToRemoteTcpDevice(transport).connect(inetSocketAddress);
-        } finally {
-            transport.close();
         }
     }
 
     public InetSocketAddress disconnectFromTcpDevice(InetSocketAddress tcpAddressEntity)
             throws IOException, JadbException, ConnectionToRemoteDeviceException {
-        Transport transport = createTransport();
-        try {
+        try (Transport transport = createTransport()) {
             return new HostDisconnectFromRemoteTcpDevice(transport).disconnect(tcpAddressEntity);
-        } finally {
-            transport.close();
         }
     }
 
     public List<JadbDevice> getDevices() throws IOException, JadbException {
-        Transport devices = createTransport();
-        devices.send("host:devices");
-        devices.verifyResponse();
-        String body = devices.readString();
-        devices.close();
-        return parseDevices(body);
+        try (Transport transport = createTransport()) {
+            transport.send("host:devices");
+            transport.verifyResponse();
+            String body = transport.readString();
+            return parseDevices(body);
+        }
     }
 
     public DeviceWatcher createDeviceWatcher(DeviceDetectionListener listener) throws IOException, JadbException {

--- a/src/se/vidstige/jadb/SyncTransport.java
+++ b/src/se/vidstige/jadb/SyncTransport.java
@@ -11,11 +11,6 @@ public class SyncTransport {
     private final DataOutput output;
     private final DataInput input;
 
-    public SyncTransport(OutputStream outputStream, InputStream inputStream) {
-        output = new DataOutputStream(outputStream);
-        input = new DataInputStream(inputStream);
-    }
-
     public SyncTransport(DataOutput outputStream, DataInput inputStream) {
         output = outputStream;
         input = inputStream;

--- a/src/se/vidstige/jadb/Transport.java
+++ b/src/se/vidstige/jadb/Transport.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 
-class Transport {
+class Transport implements Closeable {
 
     private final OutputStream outputStream;
     private final InputStream inputStream;
@@ -64,6 +64,7 @@ class Transport {
         return new SyncTransport(outputStream, inputStream);
     }
 
+    @Override
     public void close() throws IOException {
         inputStream.close();
         outputStream.close();

--- a/src/se/vidstige/jadb/Transport.java
+++ b/src/se/vidstige/jadb/Transport.java
@@ -8,10 +8,14 @@ class Transport implements Closeable {
 
     private final OutputStream outputStream;
     private final InputStream inputStream;
+    private final DataInputStream dataInput;
+    private final DataOutputStream dataOutput;
 
     private Transport(OutputStream outputStream, InputStream inputStream) {
         this.outputStream = outputStream;
         this.inputStream = inputStream;
+        this.dataInput = new DataInputStream(inputStream);
+        this.dataOutput = new DataOutputStream(outputStream);
     }
 
     public Transport(Socket socket) throws IOException {
@@ -41,9 +45,8 @@ class Transport implements Closeable {
     }
 
     public String readString(int length) throws IOException {
-        DataInput reader = new DataInputStream(inputStream);
         byte[] responseBuffer = new byte[length];
-        reader.readFully(responseBuffer);
+        dataInput.readFully(responseBuffer);
         return new String(responseBuffer, StandardCharsets.UTF_8);
     }
 
@@ -61,12 +64,12 @@ class Transport implements Closeable {
     public SyncTransport startSync() throws IOException, JadbException {
         send("sync:");
         verifyResponse();
-        return new SyncTransport(outputStream, inputStream);
+        return new SyncTransport(dataOutput, dataInput);
     }
 
     @Override
     public void close() throws IOException {
-        inputStream.close();
-        outputStream.close();
+        dataInput.close();
+        dataOutput.close();
     }
 }


### PR DESCRIPTION
This is another take on #89. I more or less left SyncTransport as it is (just removed one constructor) and everything happens in Transport. When Transport.closes either stream, everything up to Socket (including) should be closed.

Fixes #76.
