### PR TITLE
Added trim on string builder

### DIFF
--- a/src/se/vidstige/jadb/managers/PackageManager.java
+++ b/src/se/vidstige/jadb/managers/PackageManager.java
@@ -100,7 +100,7 @@ public class PackageManager {
         private final StringBuilder stringBuilder = new StringBuilder();
 
         private String getStringRepresentation() {
-            return stringBuilder.toString();
+            return stringBuilder.toString().trim();
         }
     }
 


### PR DESCRIPTION
APK Installation fails on Android P. The shell command generated is `pm install "-r " /sdcard/tmp/APK1.apk`. A trim should be applicated on each arguments