### PR TITLE
Fix: PackageManager.remove() no longer calls Bash.quote() fixing remove of apk from device.

### DIFF
--- a/src/se/vidstige/jadb/managers/PackageManager.java
+++ b/src/se/vidstige/jadb/managers/PackageManager.java
@@ -44,7 +44,7 @@ public class PackageManager {
     }
 
     private void remove(RemoteFile file) throws IOException, JadbException {
-        InputStream s = device.executeShell("rm", "-f", Bash.quote(file.getPath()));
+        InputStream s = device.executeShell("rm", "-f", file.getPath());
         Stream.readAll(s, StandardCharsets.UTF_8);
     }
 


### PR DESCRIPTION
This code fixes the removal of packages from the device after it is installed.