### PR TITLE
Allow multi-byte characters in payload

### DIFF
--- a/src/se/vidstige/jadb/SyncTransport.java
+++ b/src/se/vidstige/jadb/SyncTransport.java
@@ -19,8 +19,9 @@ public class SyncTransport {
     public void send(String syncCommand, String name) throws IOException {
         if (syncCommand.length() != 4) throw new IllegalArgumentException("sync commands must have length 4");
         output.writeBytes(syncCommand);
-        output.writeInt(Integer.reverseBytes(name.length()));
-        output.writeBytes(name);
+        byte[] data = name.getBytes();
+        output.writeInt(Integer.reverseBytes(data.length));
+        output.write(data);
     }
 
     public void sendStatus(String statusCode, int length) throws IOException {

--- a/src/se/vidstige/jadb/server/AdbDeviceResponder.java
+++ b/src/se/vidstige/jadb/server/AdbDeviceResponder.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Created by vidstige on 20/03/14.
@@ -19,4 +20,6 @@ public interface AdbDeviceResponder {
     void filePulled(RemoteFile path, ByteArrayOutputStream buffer) throws JadbException, IOException;
 
     void shell(String command, DataOutputStream stdout, DataInput stdin) throws IOException;
+
+    List<RemoteFile> list(String path) throws IOException;
 }


### PR DESCRIPTION
At the moment, `JadbDevice#list` fails if the dir name contains multi-byte characters (for example, chinese characters) because it makes the assumption that each character is only one byte