### PR TITLE
Cleanup

### DIFF
--- a/src/se/vidstige/jadb/JadbDevice.java
+++ b/src/se/vidstige/jadb/JadbDevice.java
@@ -186,7 +186,7 @@ public class JadbDevice {
     public void push(InputStream source, long lastModified, int mode, RemoteFile remote) throws IOException, JadbException {
         try (Transport transport = getTransport()) {
             SyncTransport sync = transport.startSync();
-            sync.send("SEND", remote.getPath() + "," + Integer.toString(mode));
+            sync.send("SEND", remote.getPath() + "," + mode);
 
             sync.sendStream(source);
 

--- a/src/se/vidstige/jadb/RemoteFile.java
+++ b/src/se/vidstige/jadb/RemoteFile.java
@@ -10,7 +10,7 @@ public class RemoteFile {
 
     public String getName() { throw new UnsupportedOperationException(); }
     public int getSize() { throw new UnsupportedOperationException(); }
-    public long getLastModified() { throw new UnsupportedOperationException(); }
+    public int getLastModified() { throw new UnsupportedOperationException(); }
     public boolean isDirectory() { throw new UnsupportedOperationException(); }
 
     public String getPath() { return path;}

--- a/src/se/vidstige/jadb/RemoteFileRecord.java
+++ b/src/se/vidstige/jadb/RemoteFileRecord.java
@@ -8,9 +8,9 @@ class RemoteFileRecord extends RemoteFile {
 
     private final int mode;
     private final int size;
-    private final long lastModified;
+    private final int lastModified;
 
-    public RemoteFileRecord(String name, int mode, int size, long lastModified) {
+    public RemoteFileRecord(String name, int mode, int size, int lastModified) {
         super(name);
         this.mode = mode;
         this.size = size;
@@ -23,7 +23,7 @@ class RemoteFileRecord extends RemoteFile {
     }
 
     @Override
-    public long getLastModified() {
+    public int getLastModified() {
         return lastModified;
     }
 

--- a/src/se/vidstige/jadb/SyncTransport.java
+++ b/src/se/vidstige/jadb/SyncTransport.java
@@ -55,7 +55,7 @@ public class SyncTransport {
         output.writeBytes("DENT");
         output.writeInt(Integer.reverseBytes(0666 | (file.isDirectory() ? (1 << 14) : 0)));
         output.writeInt(Integer.reverseBytes(file.getSize()));
-        output.writeInt(Integer.reverseBytes((int)file.getLastModified()));
+        output.writeInt(Integer.reverseBytes(file.getLastModified()));
         byte[] pathChars = file.getPath().getBytes(StandardCharsets.UTF_8);
         output.writeInt(Integer.reverseBytes(pathChars.length));
         output.write(pathChars);

--- a/src/se/vidstige/jadb/SyncTransport.java
+++ b/src/se/vidstige/jadb/SyncTransport.java
@@ -55,7 +55,7 @@ public class SyncTransport {
         output.writeBytes("DENT");
         output.writeInt(Integer.reverseBytes(0666 | (file.isDirectory() ? (1 << 14) : 0)));
         output.writeInt(Integer.reverseBytes(file.getSize()));
-        output.writeInt(Integer.reverseBytes(Long.valueOf(file.getLastModified()).intValue()));
+        output.writeInt(Integer.reverseBytes((int)file.getLastModified()));
         byte[] pathChars = file.getPath().getBytes(StandardCharsets.UTF_8);
         output.writeInt(Integer.reverseBytes(pathChars.length));
         output.write(pathChars);

--- a/src/se/vidstige/jadb/server/AdbProtocolHandler.java
+++ b/src/se/vidstige/jadb/server/AdbProtocolHandler.java
@@ -178,13 +178,19 @@ class AdbProtocolHandler implements Runnable {
         try {
             String id = readString(input, 4);
             int length = readInt(input);
-            if ("SEND".equals(id)) {
-                syncSend(output, input, length);
-            } else if ("RECV".equals(id)) {
-                syncRecv(output, input, length);
-            } else if ("LIST".equals(id)) {
-                syncList(output, input, length);
-            } else throw new JadbException("Unknown sync id " + id);
+            switch (id) {
+                case "SEND":
+                    syncSend(output, input, length);
+                    break;
+                case "RECV":
+                    syncRecv(output, input, length);
+                    break;
+                case "LIST":
+                    syncList(output, input, length);
+                    break;
+                default:
+                    throw new JadbException("Unknown sync id " + id);
+            }
         } catch (JadbException e) { // sync response with a different type of fail message
             SyncTransport sync = getSyncTransport(output, input);
             sync.send("FAIL", e.getMessage());

--- a/test/se/vidstige/jadb/test/fakes/FakeAdbServer.java
+++ b/test/se/vidstige/jadb/test/fakes/FakeAdbServer.java
@@ -269,12 +269,12 @@ public class FakeAdbServer implements AdbResponder {
                 return remotePath.equals(this.remotePath);
             }
 
-            public ListExpectation withFile(String path, int size, long modifyTime) {
+            public ListExpectation withFile(String path, int size, int modifyTime) {
                 files.add(new MockFileEntry(path, size, modifyTime, false));
                 return this;
             }
 
-            public ListExpectation withDir(String path, long modifyTime) {
+            public ListExpectation withDir(String path, int modifyTime) {
                 files.add(new MockFileEntry(path, -1, modifyTime, true));
                 return this;
             }
@@ -286,10 +286,10 @@ public class FakeAdbServer implements AdbResponder {
             private static class MockFileEntry extends RemoteFile {
 
                 private final int size;
-                private final long modifyTime;
+                private final int modifyTime;
                 private final boolean dir;
 
-                MockFileEntry(String path, int size, long modifyTime, boolean dir) {
+                MockFileEntry(String path, int size, int modifyTime, boolean dir) {
                     super(path);
                     this.size = size;
                     this.modifyTime = modifyTime;
@@ -300,7 +300,7 @@ public class FakeAdbServer implements AdbResponder {
                     return size;
                 }
 
-                public long getLastModified() {
+                public int getLastModified() {
                     return modifyTime;
                 }
 

--- a/test/se/vidstige/jadb/test/unit/MockedTestCases.java
+++ b/test/se/vidstige/jadb/test/unit/MockedTestCases.java
@@ -130,21 +130,21 @@ public class MockedTestCases {
     public void testFileList() throws Exception {
         server.add("serial-123");
         server.expectList("serial-123", "/sdcard/Documents")
-                .withDir("school", 123456789L)
-                .withDir("finances", 7070707L)
-                .withDir("\u904A\u6232", 528491L)
-                .withFile("user_manual.pdf", 3000, 648649L)
-                .withFile("effective java vol. 7.epub", 0xCAFE, 0xBABEL)
-                .withFile("\uB9AC\uADF8 \uC624\uBE0C \uB808\uC804\uB4DC", 240, 9001L);
+                .withDir("school", 123456789)
+                .withDir("finances", 7070707)
+                .withDir("\u904A\u6232", 528491)
+                .withFile("user_manual.pdf", 3000, 648649)
+                .withFile("effective java vol. 7.epub", 0xCAFE, 0xBABE)
+                .withFile("\uB9AC\uADF8 \uC624\uBE0C \uB808\uC804\uB4DC", 240, 9001);
         JadbDevice device = connection.getDevices().get(0);
         List<RemoteFile> files = device.list("/sdcard/Documents");
         Assert.assertEquals(6, files.size());
-        assertHasDir("school", 123456789L, files);
-        assertHasDir("finances", 7070707L, files);
-        assertHasDir("\u904A\u6232", 528491L, files);
-        assertHasFile("user_manual.pdf", 3000, 648649L, files);
-        assertHasFile("effective java vol. 7.epub", 0xCAFE, 0xBABEL, files);
-        assertHasFile("\uB9AC\uADF8 \uC624\uBE0C \uB808\uC804\uB4DC", 240, 9001L, files);
+        assertHasDir("school", 123456789, files);
+        assertHasDir("finances", 7070707, files);
+        assertHasDir("\u904A\u6232", 528491, files);
+        assertHasFile("user_manual.pdf", 3000, 648649, files);
+        assertHasFile("effective java vol. 7.epub", 0xCAFE, 0xBABE, files);
+        assertHasFile("\uB9AC\uADF8 \uC624\uBE0C \uB808\uC804\uB4DC", 240, 9001, files);
     }
 
     private static long parseDate(String date) throws ParseException {


### PR DESCRIPTION
This PR fixes some issues found by sonarqube/sonarlint:

- some calls are not needed
- RemoteFileRecord should implement equals/hashCode

In addition, it seems that RemoteFile.getTimestamp() can return int instead of long.