### PR TITLE
Quote all arguments #123

### DIFF
--- a/src/se/vidstige/jadb/managers/Bash.java
+++ b/src/se/vidstige/jadb/managers/Bash.java
@@ -6,10 +6,6 @@ public class Bash {
     }
 
     public static String quote(String s) {
-        // Check that s contains no whitespace
-        if (s.matches("\\S+")) {
-            return s;
-        }
         return "'" + s.replace("'", "'\\''") + "'";
     }
 }


### PR DESCRIPTION
Bash.quote should quote all strings not just spaces, otherwise, other special characters will be interpreted and not passed literally to the command.