### PR TITLE
filter not allowed characters out of the adb protocol

### DIFF
--- a/src/se/vidstige/jadb/Transport.java
+++ b/src/se/vidstige/jadb/Transport.java
@@ -51,7 +51,7 @@ class Transport implements Closeable {
     }
 
     private String getCommandLength(String command) {
-        return String.format("%04x", command.length());
+        return String.format("%04x", command.getBytes().length);
     }
 
     public void send(String command) throws IOException {

--- a/src/se/vidstige/jadb/managers/Bash.java
+++ b/src/se/vidstige/jadb/managers/Bash.java
@@ -6,10 +6,6 @@ public class Bash {
     }
 
     public static String quote(String s) {
-        // Check that s contains no whitespace
-        if (s.matches("\\S+")) {
-            return s;
-        }
         return "'" + s.replace("'", "'\\''") + "'";
     }
 }

--- a/test/se/vidstige/jadb/test/integration/ExecuteCmdTests.java
+++ b/test/se/vidstige/jadb/test/integration/ExecuteCmdTests.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import se.vidstige.jadb.JadbConnection;
 import se.vidstige.jadb.JadbDevice;
+import se.vidstige.jadb.Stream;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -60,41 +61,6 @@ public class ExecuteCmdTests {
     @Test
     public void testExecuteWithSpecialChars() throws Exception {
         InputStream response = jadbDevice.execute("echo", input);
-        ResponseReader responseReader = new ResponseReader(response);
-        responseReader.start();
-        responseReader.join(1000L);
-        String ret = responseReader.output;
-        //remove newline
-        ret = ret.replaceAll("\n$", "");
-        Assert.assertEquals(input, ret);
+        Assert.assertEquals(input, Stream.readAll(response, StandardCharsets.UTF_8).replaceAll("\n$", ""));
     }
-
-
-    private class ResponseReader extends Thread {
-        public String output;
-        private InputStream response;
-
-        ResponseReader(InputStream response) {
-            super();
-            this.response = response;
-        }
-
-        @Override
-        public void run() {
-            try {
-                StringBuilder textBuilder = new StringBuilder();
-                try (Reader reader = new BufferedReader(new InputStreamReader
-                        (response, Charset.forName(StandardCharsets.UTF_8.name())))) {
-                    int c = 0;
-                    while ((c = reader.read()) != -1) {
-                        textBuilder.append((char) c);
-                    }
-                }
-                output = textBuilder.toString();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
 }

--- a/test/se/vidstige/jadb/test/integration/ExecuteCmdTests.java
+++ b/test/se/vidstige/jadb/test/integration/ExecuteCmdTests.java
@@ -1,0 +1,100 @@
+package se.vidstige.jadb.test.integration;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import se.vidstige.jadb.JadbConnection;
+import se.vidstige.jadb.JadbDevice;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class ExecuteCmdTests {
+    private static JadbConnection jadb;
+    private static JadbDevice jadbDevice;
+
+    @Parameterized.Parameter
+    public String input;
+
+
+    @Parameterized.Parameters(name="Test {index} input={0}")
+    public static Collection input() {
+        return Arrays.asList(new Object[]{
+                "öäasd",
+                "asf dsa",
+                "sdf&g",
+                "sd& fg",
+                "da~f",
+                "asd'as",
+                "a¡f",
+                "asüd",
+                "adös tz",
+                "⾀",
+                "å",
+                "æ",
+                "{}"});
+    }
+
+    @BeforeClass
+    public static void connect() {
+        try {
+            jadb = new JadbConnection();
+            jadb.getHostVersion();
+            jadbDevice = jadb.getAnyDevice();
+        } catch (Exception e) {
+            org.junit.Assume.assumeNoException(e);
+        }
+    }
+
+
+    @Test
+    public void testExecuteWithSpecialChars() throws Exception {
+        InputStream response = jadbDevice.execute("echo", input);
+        ResponseReader responseReader = new ResponseReader(response);
+        responseReader.start();
+        responseReader.join(1000L);
+        String ret = responseReader.output;
+        //remove newline
+        ret = ret.replaceAll("\n$", "");
+        Assert.assertEquals(input, ret);
+    }
+
+
+    private class ResponseReader extends Thread {
+        public String output;
+        private InputStream response;
+
+        ResponseReader(InputStream response) {
+            super();
+            this.response = response;
+        }
+
+        @Override
+        public void run() {
+            try {
+                StringBuilder textBuilder = new StringBuilder();
+                try (Reader reader = new BufferedReader(new InputStreamReader
+                        (response, Charset.forName(StandardCharsets.UTF_8.name())))) {
+                    int c = 0;
+                    while ((c = reader.read()) != -1) {
+                        textBuilder.append((char) c);
+                    }
+                }
+                output = textBuilder.toString();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+}

--- a/test/se/vidstige/jadb/test/unit/MockedTestCases.java
+++ b/test/se/vidstige/jadb/test/unit/MockedTestCases.java
@@ -119,11 +119,15 @@ public class MockedTestCases {
         server.expectShell("serial-123", "echo 'tab\tstring'").returns("tab\tstring");
         server.expectShell("serial-123", "echo 'newline1\nstring'").returns("newline1\nstring");
         server.expectShell("serial-123", "echo 'newline2\r\nstring'").returns("newline2\r\nstring");
+        server.expectShell("serial-123", "echo 'fuö äzpo'").returns("fuö äzpo");
+        server.expectShell("serial-123", "echo 'h¡t]&poli'").returns("h¡t]&poli");
         JadbDevice device = connection.getDevices().get(0);
         device.executeShell("ls", "space file");
         device.executeShell("echo", "tab\tstring");
         device.executeShell("echo", "newline1\nstring");
         device.executeShell("echo", "newline2\r\nstring");
+        device.executeShell("echo", "fuö äzpo");
+        device.executeShell("echo", "h¡t]&poli");
     }
 
     @Test


### PR DESCRIPTION
and also put every argument in quotes. Not only space characters need quoting, also &(){}~ and many more.