### PR TITLE
fix FakeADBServer testcases which expect certain commands

### DIFF
--- a/test/se/vidstige/jadb/test/unit/MockedTestCases.java
+++ b/test/se/vidstige/jadb/test/unit/MockedTestCases.java
@@ -99,7 +99,7 @@ public class MockedTestCases {
     @Test
     public void testExecuteShell() throws Exception {
         server.add("serial-123");
-        server.expectShell("serial-123", "ls -l").returns("total 0");
+        server.expectShell("serial-123", "ls '-l'").returns("total 0");
         JadbDevice device = connection.getDevices().get(0);
         device.executeShell("ls", "-l");
     }

--- a/test/se/vidstige/jadb/test/unit/PackageManagerTest.java
+++ b/test/se/vidstige/jadb/test/unit/PackageManagerTest.java
@@ -44,7 +44,7 @@ public class PackageManagerTest {
         String response = "package:/system/priv-app/Contacts.apk-com.android.contacts\n" +
                 "package:/system/priv-app/Teleservice.apk-com.android.phone";
 
-        server.expectShell(DEVICE_SERIAL, "pm list packages").returns(response);
+        server.expectShell(DEVICE_SERIAL, "pm 'list' 'packages'").returns(response);
 
         //Act
         List<Package> actual = new PackageManager(device).getPackages();
@@ -64,7 +64,7 @@ public class PackageManagerTest {
                 "[malformed_line]\n" +
                 "package:/system/priv-app/Teleservice.apk-com.android.phone";
 
-        server.expectShell(DEVICE_SERIAL, "pm list packages").returns(response);
+        server.expectShell(DEVICE_SERIAL, "pm 'list' 'packages'").returns(response);
 
         //Act
         List<Package> actual = new PackageManager(device).getPackages();
@@ -79,7 +79,7 @@ public class PackageManagerTest {
         List<Package> expected = new ArrayList<>();
         String response = "";
 
-        server.expectShell(DEVICE_SERIAL, "pm list packages").returns(response);
+        server.expectShell(DEVICE_SERIAL, "pm 'list' 'packages'").returns(response);
 
         //Act
         List<Package> actual = new PackageManager(device).getPackages();


### PR DESCRIPTION
since now everything is quoted. the expected commands of the FakeADBServer should also be quoted. Otherwise, the FakeADBServer never receives the expected command and thus never sends a response and the test is stuck forever waiting for a ADB response.