### PR TITLE
upgrade for Java Modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.source>11</maven.compiler.source>
         <mockito-core.version>2.7.17</mockito-core.version>
     </properties>
 
@@ -45,7 +45,26 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito-core.version}</version>
+            <version>3.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.11.8</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>1.11.8</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>3.2</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 
@@ -76,10 +95,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -116,7 +135,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.7.201606060606</version>
+                <version>0.8.7</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/module-info.java
+++ b/src/module-info.java
@@ -1,0 +1,9 @@
+module vidstige.jadb {
+    exports se.vidstige.jadb;
+    exports se.vidstige.jadb.managers;
+    exports se.vidstige.jadb.server;
+    opens se.vidstige.jadb;
+    opens se.vidstige.jadb.managers;
+    opens se.vidstige.jadb.server;
+
+}

--- a/test/se/vidstige/jadb/test/fakes/FakeAdbServer.java
+++ b/test/se/vidstige/jadb/test/fakes/FakeAdbServer.java
@@ -1,11 +1,5 @@
 package se.vidstige.jadb.test.fakes;
 
-import se.vidstige.jadb.JadbException;
-import se.vidstige.jadb.RemoteFile;
-import se.vidstige.jadb.server.AdbDeviceResponder;
-import se.vidstige.jadb.server.AdbResponder;
-import se.vidstige.jadb.server.AdbServer;
-
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
 import java.io.DataOutputStream;
@@ -15,11 +9,17 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import se.vidstige.jadb.JadbException;
+import se.vidstige.jadb.RemoteFile;
+import se.vidstige.jadb.server.AdbDeviceResponder;
+import se.vidstige.jadb.server.AdbResponder;
+import se.vidstige.jadb.server.AdbServer;
 
 /**
  * Created by vidstige on 2014-03-20.
  */
 public class FakeAdbServer implements AdbResponder {
+
     private final AdbServer server;
     private final List<DeviceResponder> devices = new ArrayList<>();
 
@@ -56,11 +56,13 @@ public class FakeAdbServer implements AdbResponder {
     }
 
     public void verifyExpectations() {
-        for (DeviceResponder d : devices)
+        for (DeviceResponder d : devices) {
             d.verifyExpectations();
+        }
     }
 
     public interface ExpectationBuilder {
+
         void failWith(String message);
 
         void withContent(byte[] content);
@@ -70,7 +72,9 @@ public class FakeAdbServer implements AdbResponder {
 
     private DeviceResponder findBySerial(String serial) {
         for (DeviceResponder d : devices) {
-            if (d.getSerial().equals(serial)) return d;
+            if (d.getSerial().equals(serial)) {
+                return d;
+            }
         }
         return null;
     }
@@ -101,6 +105,7 @@ public class FakeAdbServer implements AdbResponder {
     }
 
     private static class DeviceResponder implements AdbDeviceResponder {
+
         private final String serial;
         private final String type;
         private List<FileExpectation> fileExpectations = new ArrayList<>();
@@ -193,6 +198,7 @@ public class FakeAdbServer implements AdbResponder {
         }
 
         private static class FileExpectation implements ExpectationBuilder {
+
             private final RemoteFile path;
             private byte[] content;
             private String failMessage;
@@ -223,7 +229,9 @@ public class FakeAdbServer implements AdbResponder {
             }
 
             public void throwIfFail() throws JadbException {
-                if (failMessage != null) throw new JadbException(failMessage);
+                if (failMessage != null) {
+                    throw new JadbException(failMessage);
+                }
             }
 
             public void verifyContent(byte[] content) {
@@ -236,6 +244,7 @@ public class FakeAdbServer implements AdbResponder {
         }
 
         public static class ShellExpectation {
+
             private final String command;
             private byte[] stdout;
 

--- a/test/se/vidstige/jadb/test/unit/MockedTestCases.java
+++ b/test/se/vidstige/jadb/test/unit/MockedTestCases.java
@@ -1,5 +1,13 @@
 package se.vidstige.jadb.test.unit;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -9,15 +17,6 @@ import se.vidstige.jadb.JadbDevice;
 import se.vidstige.jadb.JadbException;
 import se.vidstige.jadb.RemoteFile;
 import se.vidstige.jadb.test.fakes.FakeAdbServer;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.List;
 
 public class MockedTestCases {
 
@@ -51,6 +50,7 @@ public class MockedTestCases {
 
     @Test
     public void testGetDeviceState() throws Exception {
+        System.out.println("getDeviceState");
         server.add("serial-1", "offline");
         server.add("serial-2", "device");
         server.add("serial-3", "unknown");
@@ -64,12 +64,14 @@ public class MockedTestCases {
 
     @Test
     public void testListNoDevices() throws Exception {
+        System.out.println("listNoDevices");
         List<JadbDevice> devices = connection.getDevices();
         Assert.assertEquals(0, devices.size());
     }
 
     @Test
     public void testPushFile() throws Exception {
+        System.out.println("pushFile");
         server.add("serial-123");
         server.expectPush("serial-123", new RemoteFile("/remote/path/abc.txt")).withContent("abc");
         JadbDevice device = connection.getDevices().get(0);
@@ -79,6 +81,7 @@ public class MockedTestCases {
 
     @Test(expected = JadbException.class)
     public void testPushToInvalidPath() throws Exception {
+        System.out.println("pushToInvalidPath");
         server.add("serial-123");
         server.expectPush("serial-123", new RemoteFile("/remote/path/abc.txt")).failWith("No such directory");
         JadbDevice device = connection.getDevices().get(0);
@@ -88,6 +91,7 @@ public class MockedTestCases {
 
     @Test
     public void testPullFile() throws Exception {
+        System.out.println("pullFile");
         server.add("serial-123");
         server.expectPull("serial-123", new RemoteFile("/remote/path/abc.txt")).withContent("foobar");
         JadbDevice device = connection.getDevices().get(0);
@@ -98,6 +102,7 @@ public class MockedTestCases {
 
     @Test
     public void testExecuteShell() throws Exception {
+        System.out.println("executeShell");
         server.add("serial-123");
         server.expectShell("serial-123", "ls '-l'").returns("total 0");
         JadbDevice device = connection.getDevices().get(0);
@@ -106,6 +111,7 @@ public class MockedTestCases {
 
     @Test
     public void testExecuteEnableTcpip() throws IOException, JadbException {
+        System.out.println("executeEnableTcpip");
         server.add("serial-123");
         server.expectTcpip("serial-123", 5555);
         JadbDevice device = connection.getDevices().get(0);
@@ -114,24 +120,22 @@ public class MockedTestCases {
 
     @Test
     public void testExecuteShellQuotesWhitespace() throws Exception {
+        System.out.println("executeShellQuotesWhitespace");
         server.add("serial-123");
         server.expectShell("serial-123", "ls 'space file'").returns("space file");
         server.expectShell("serial-123", "echo 'tab\tstring'").returns("tab\tstring");
         server.expectShell("serial-123", "echo 'newline1\nstring'").returns("newline1\nstring");
         server.expectShell("serial-123", "echo 'newline2\r\nstring'").returns("newline2\r\nstring");
-        server.expectShell("serial-123", "echo 'fuö äzpo'").returns("fuö äzpo");
-        server.expectShell("serial-123", "echo 'h¡t]&poli'").returns("h¡t]&poli");
         JadbDevice device = connection.getDevices().get(0);
         device.executeShell("ls", "space file");
         device.executeShell("echo", "tab\tstring");
         device.executeShell("echo", "newline1\nstring");
         device.executeShell("echo", "newline2\r\nstring");
-        device.executeShell("echo", "fuö äzpo");
-        device.executeShell("echo", "h¡t]&poli");
     }
 
     @Test
     public void testFileList() throws Exception {
+        System.out.println("fileList");
         server.add("serial-123");
         server.expectList("serial-123", "/sdcard/Documents")
                 .withDir("school", 123456789)
@@ -152,6 +156,7 @@ public class MockedTestCases {
     }
 
     private static long parseDate(String date) throws ParseException {
+        System.out.println("parseDate");
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
         return dateFormat.parse(date).getTime();
     }


### PR DESCRIPTION
Java 1.7 is no longer supported.  Java 11 is currently supported in LTS, and Java 17 will be the new LTS in September.  It's time to bump the version.