### PR TITLE
Add explicit constructor

### DIFF
--- a/src/se/vidstige/jadb/Subprocess.java
+++ b/src/se/vidstige/jadb/Subprocess.java
@@ -2,6 +2,12 @@ package se.vidstige.jadb;
 
 import java.io.IOException;
 
+    /**
+     * Explicit default public constructor.
+     */
+    public Subprocess(){
+        //emtpy
+    }
 public class Subprocess {
     public Process execute(String[] command) throws IOException {
         return Runtime.getRuntime().exec(command);


### PR DESCRIPTION
Fixes a message with this class when modularized
`se/vidstige/jadb/Subprocess.java:[23,8] class se.vidstige.jadb.Subprocess in exported package se.vidstige.jadb declares no explicit constructors, thereby exposing a default constructor to clients of module my.module.`